### PR TITLE
Update `vm2.TestUtilities` + minor fixes in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ See prereleases below.
 
 ## v3.0.1-preview.2 - 2026-04-10
 
-See prereleases below.
-
-## v3.0.1-preview.2 - 2026-04-10
-
 ### Internal
 
 - clean up CHANGELOG formatting and update cliff.prerelease.toml template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,19 @@
 - UlidTests inherit from TestBase, update CHANGELOG for breaking changes in Ulid struct and improve formatting
 
 
-
 ## v3.0.2 - 2026-04-10
+
 See prereleases below.
 
 ## v3.0.1-preview.2 - 2026-04-10
+
 See prereleases below.
+
 ## v3.0.1-preview.2 - 2026-04-10
 
 ### Internal
 
 - clean up CHANGELOG formatting and update cliff.prerelease.toml template
-
 
 ## v3.0.1 - 2026-04-10
 
@@ -270,12 +271,12 @@ DevOps build pipeline changes
 >
 > **Removed**
 >
-> - add removed/obsolete items here
-> - commit prefix for git-cliff: `revert:`
+> - add removed/obsolete items
+> - commit prefix for git-cliff: `revert:` or `remove:`
 >
 > **Security**
 >
-> - add security-related changes here
+> - add security-related changes
 > - commit prefix for git-cliff: `security:`
 >
 > **Internal**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,14 +125,15 @@ DevOps changes only.
 
 ### Removed
 
-- **BREAKING:** Removed the static methods `GetTimestampFromUlid(in ReadOnlySpan<byte> ulidBytes)` and
+- **BREAKING:** removed the static methods `GetTimestampFromUlid(in ReadOnlySpan<byte>
+  ulidBytes)` and
   `PutTimestampToUlid(in DateTime timestamp, Span<byte> ulidBytes)` from the `Ulid` struct, as they were not consistent with
   the rest of the API and had confusing semantics.
 
   This is a breaking change because any code that called these methods will no longer compile. If users need to get or put
   timestamps in ULIDs, they can use the `UlidFactory` class with the appropriate providers instead.
 
-- **BREAKING:** Removed the parameter of the static method `Ulid.NewUlid(/*IUlidRandomProvider?
+- **BREAKING:** removed the parameter of the static method `Ulid.NewUlid(/*IUlidRandomProvider?
   ulidRandomProvider = null*/)`, as it had confusing side effects and was incomplete: it accepted a random provider but no
   timestamp provider. Now, the method simply generates a new ULID using the default random and timestamp providers.
 
@@ -140,14 +141,14 @@ DevOps changes only.
   If users need to use a custom random provider, they can create an instance of `UlidFactory` with the desired providers and
   call `factory.NewUlid()` instead.
 
-- **BREAKING:** Removed the method `public readonly bool TryWrite(Span<byte> destination, bool asUtf8)`. Use
+- **BREAKING:** removed the method `public readonly bool TryWrite(Span<byte> destination, bool asUtf8)`. Use
   `public readonly bool TryWriteUtf8(in Span<byte> destination)` instead, to clarify the semantics of writing ULIDs as UTF-8
   encoded byte spans.
 
 ### Added
 
-Add new overloads `Ulid.Parse(ReadOnlySpan<byte> utf8Bytes)` and `Ulid.TryParse(ReadOnlySpan<byte> utf8Bytes, out Ulid result)`
-to parse ULIDs from UTF-8 encoded byte spans. The existing `Parse` and `TryParse` methods that take `ReadOnlySpan<char>` are
+Added new overloads `Ulid.Parse(ReadOnlySpan<byte> utf8Bytes)` and `Ulid.TryParse(ReadOnlySpan<byte> utf8Bytes, out Ulid result)
+` to parse ULIDs from UTF-8 encoded byte spans. The existing `Parse` and `TryParse` methods that take `ReadOnlySpan<char>` are
 still available and unchanged.
 
 ### Performance
@@ -164,8 +165,8 @@ DevOps build pipeline changes.
 
 ### Added
 
-UlidTool project to provide a command-line interface for generating and parsing ULIDs. The tool is built on top of the
-`vm2.Ulid` library and can be used for quick ULID generation or parsing without writing code.
+UlidTool project to provide a command-line interface for generating and parsing ULIDs. The tool is built on top of the `vm2.
+Ulid` library and can be used for quick ULID generation or parsing without writing code.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,14 +125,14 @@ DevOps changes only.
 
 ### Removed
 
-- **BREAKING:** removed the static methods `GetTimestampFromUlid(in ReadOnlySpan<byte> ulidBytes)` and
+- **BREAKING:** Removed the static methods `GetTimestampFromUlid(in ReadOnlySpan<byte> ulidBytes)` and
   `PutTimestampToUlid(in DateTime timestamp, Span<byte> ulidBytes)` from the `Ulid` struct, as they were not consistent with
   the rest of the API and had confusing semantics.
 
   This is a breaking change because any code that called these methods will no longer compile. If users need to get or put
   timestamps in ULIDs, they can use the `UlidFactory` class with the appropriate providers instead.
 
-- **BREAKING:** removed the parameter of the static method `Ulid.NewUlid(/*IUlidRandomProvider?
+- **BREAKING:** Removed the parameter of the static method `Ulid.NewUlid(/*IUlidRandomProvider?
   ulidRandomProvider = null*/)`, as it had confusing side effects and was incomplete: it accepted a random provider but no
   timestamp provider. Now, the method simply generates a new ULID using the default random and timestamp providers.
 
@@ -140,14 +140,14 @@ DevOps changes only.
   If users need to use a custom random provider, they can create an instance of `UlidFactory` with the desired providers and
   call `factory.NewUlid()` instead.
 
-- **BREAKING:** removed the method `public readonly bool TryWrite(Span<byte> destination, bool asUtf8)`. Use
+- **BREAKING:** Removed the method `public readonly bool TryWrite(Span<byte> destination, bool asUtf8)`. Use
   `public readonly bool TryWriteUtf8(in Span<byte> destination)` instead, to clarify the semantics of writing ULIDs as UTF-8
   encoded byte spans.
 
 ### Added
 
-Added new overloads `Ulid.Parse(ReadOnlySpan<byte> utf8Bytes)` and `Ulid.TryParse(ReadOnlySpan<byte> utf8Bytes, out Ulid result)
-` to parse ULIDs from UTF-8 encoded byte spans. The existing `Parse` and `TryParse` methods that take `ReadOnlySpan<char>` are
+Add new overloads `Ulid.Parse(ReadOnlySpan<byte> utf8Bytes)` and `Ulid.TryParse(ReadOnlySpan<byte> utf8Bytes, out Ulid result)`
+to parse ULIDs from UTF-8 encoded byte spans. The existing `Parse` and `TryParse` methods that take `ReadOnlySpan<char>` are
 still available and unchanged.
 
 ### Performance
@@ -164,8 +164,8 @@ DevOps build pipeline changes.
 
 ### Added
 
-UlidTool project to provide a command-line interface for generating and parsing ULIDs. The tool is built on top of the `vm2.
-Ulid` library and can be used for quick ULID generation or parsing without writing code.
+UlidTool project to provide a command-line interface for generating and parsing ULIDs. The tool is built on top of the
+`vm2.Ulid` library and can be used for quick ULID generation or parsing without writing code.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## v3.0.3-preview.1 - 2026-04-11
 
 ### Internal
@@ -9,7 +8,6 @@
 - update CHANGELOG to reflect removal of inconsistent static methods from Ulid struct
 - update vm2.TestUtilities to version 1.4.0 and inherit test classes from TestBase
 - UlidTests inherit from TestBase, update CHANGELOG for breaking changes in Ulid struct and improve formatting
-
 
 ## v3.0.2 - 2026-04-10
 
@@ -27,10 +25,6 @@ See prereleases below.
 
 - curate changelog for v2.0.1-preview.1 through v3.0.0
 - update changelog for v3.0.1 [skip ci]
-
-## v3.0.1 - 2026-04-10
-
-See prereleases below.
 
 ## v3.0.1-preview.1 - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,9 +147,9 @@ DevOps changes only.
 
 ### Added
 
-Add new overloads `Ulid.Parse(ReadOnlySpan<byte> utf8Bytes)` and `Ulid.TryParse(ReadOnlySpan<byte> utf8Bytes, out Ulid result)`
-to parse ULIDs from UTF-8 encoded byte spans. The existing `Parse` and `TryParse` methods that take `ReadOnlySpan<char>` are
-still available and unchanged.
+Added new overloads `Ulid.Parse(ReadOnlySpan<byte> utf8Bytes)` and
+`Ulid.TryParse(ReadOnlySpan<byte> utf8Bytes, out Ulid result)` to parse ULIDs from UTF-8 encoded byte spans. The existing
+`Parse` and `TryParse` methods that take `ReadOnlySpan<char>` are still available and unchanged.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,8 +125,7 @@ DevOps changes only.
 
 ### Removed
 
-- **BREAKING:** removed the static methods `GetTimestampFromUlid(in ReadOnlySpan<byte>
-  ulidBytes)` and
+- **BREAKING:** removed the static methods `GetTimestampFromUlid(in ReadOnlySpan<byte> ulidBytes)` and
   `PutTimestampToUlid(in DateTime timestamp, Span<byte> ulidBytes)` from the `Ulid` struct, as they were not consistent with
   the rest of the API and had confusing semantics.
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,6 +1,6 @@
 # Codecov configuration
 # Documentation: https://docs.codecov.com/docs/codecov-yaml
-# Validation: `curl -X POST --data-binary @codecov.yml https://codecov.io/validate`
+# Validation: `curl -X POST --data-binary @codecov.yaml https://codecov.io/validate`
 
 coverage:
   precision: 2 # Report coverage to 2 decimal places

--- a/coverage.settings.xml
+++ b/coverage.settings.xml
@@ -28,7 +28,7 @@
 
                 <!-- Compiler-generated -->
                 <Source>.*\\&lt;&gt;c.*\.cs$</Source>
-                <Source>*.MoveNext.*</Source>
+                <Source>.*MoveNext.*</Source>
                 <Source>.*\\d__.*\.cs$</Source>
 
                 <!-- Test files -->


### PR DESCRIPTION
# Summary

<!-- Brief description of what this PR does and why. -->

## Commits

- docs: update CHANGELOG to stick to common formatting for breaking changes
- docs: update CHANGELOG to reflect removal of inconsistent static methods from Ulid struct
- refactor: update vm2.TestUtilities to version 1.4.0 and inherit test classes from TestBase
- refactor: UlidTests inherit from TestBase, update CHANGELOG for breaking changes in Ulid struct and improve formatting
- Merge branch 'main' into fix/changelog
- docs: update CHANGELOG formatting and improve clarity in Codecov configuration

## Checklist

- [x] Commit messages follow Conventional Commits format
- [x] CHANGELOG entries are accurate and well-written
- [x] Tests pass locally