### PR TITLE
chore/template sync round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 
+## v3.1.0-preview.1 - 2026-04-14
+
+### Fixed
+
+- update tag_pattern regex to enforce semantic versioning format
+- tighten tag_pattern in cliff.prerelease.toml to strict SemVer with prerelease suffix
+
+
+### Internal
+
+- cosmetic
+- bump vm2.TestUtilities to 1.4.2 and align changelog parser
+- update documentation regex for commit messages and add pull request template
+- update changelog release-header template
+- update gitmessage template
+
+
+### deps
+
+- Bump the minor-and-patch group with 1 update
+
+
 ## v3.0.3-preview.2 - 2026-04-11
 
 ### Fixed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
         <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
         <PackageVersion Include="xunit.v3.runner.inproc" Version="3.2.2" />
-        <PackageVersion Include="vm2.TestUtilities" Version="1.4.2" />
+        <PackageVersion Include="vm2.TestUtilities" Version="1.4.3" />
         <!-- Benchmarking packages: -->
         <!-- for running with Visual Studio profiler:<PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />-->
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/changelog/cliff.prerelease.toml
+++ b/changelog/cliff.prerelease.toml
@@ -26,7 +26,7 @@ footer = ""
 [git]
 conventional_commits = true
 filter_unconventional = true
-tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+-[a-zA-Z0-9._-]+$"
+tag_pattern = "v[0-9].*"
 protect_breaking_commits = true
 commit_parsers = [
     { message = "^style", group = "Internal" },

--- a/test/UlidTool.Tests/packages.lock.json
+++ b/test/UlidTool.Tests/packages.lock.json
@@ -219,9 +219,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[1.4.2, )",
-        "resolved": "1.4.2",
-        "contentHash": "/EedoknMVrBdTjxDIvdYhLqeLHzLuFc+MCmof5vDR9uMYJIwvheoU92uIo4G7osDJCf+BEAOoc7Zsh/Ds3cMQg==",
+        "requested": "[1.4.3, )",
+        "resolved": "1.4.3",
+        "contentHash": "/6CC/8q+Tqc6X88IFeWjkT5BobQvrY8sjf3IfCXJAOS9+BvPGMJijJyiWaR+mybkRUs8oCBeHEUudSras32EJQ==",
         "dependencies": {
           "FluentAssertions": "8.9.0",
           "Microsoft.Extensions.Configuration.Binder": "10.0.5",

--- a/test/UlidType.Tests/packages.lock.json
+++ b/test/UlidType.Tests/packages.lock.json
@@ -219,9 +219,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[1.4.2, )",
-        "resolved": "1.4.2",
-        "contentHash": "/EedoknMVrBdTjxDIvdYhLqeLHzLuFc+MCmof5vDR9uMYJIwvheoU92uIo4G7osDJCf+BEAOoc7Zsh/Ds3cMQg==",
+        "requested": "[1.4.3, )",
+        "resolved": "1.4.3",
+        "contentHash": "/6CC/8q+Tqc6X88IFeWjkT5BobQvrY8sjf3IfCXJAOS9+BvPGMJijJyiWaR+mybkRUs8oCBeHEUudSras32EJQ==",
         "dependencies": {
           "FluentAssertions": "8.9.0",
           "Microsoft.Extensions.Configuration.Binder": "10.0.5",


### PR DESCRIPTION
# Summary

See the commits

## Commits

- chore: update vm2.TestUtilities version to 1.4.3 and adjust tag_pattern for semantic versioning
- chore: update changelog for v3.1.0-preview.1 [skip ci]

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests pass locally, and cover new code and edge cases. Test coverage is above 80%.
- [x] It is not expected that the performance will degrade by more than 20%
- [x] Documentation is updated if necessary