### PR TITLE
chore: sync round-3 changelog templates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
         <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
         <PackageVersion Include="xunit.v3.runner.inproc" Version="3.2.2" />
-        <PackageVersion Include="vm2.TestUtilities" Version="1.4.3" />
+        <PackageVersion Include="vm2.TestUtilities" Version="1.4.4" />
         <!-- Benchmarking packages: -->
         <!-- for running with Visual Studio profiler:<PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />-->
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/changelog/cliff.prerelease.toml
+++ b/changelog/cliff.prerelease.toml
@@ -1,10 +1,22 @@
 [changelog]
 header = """# Changelog\n\n"""
-body = """{% if tag is defined %}{% set current_tag = tag %}{% elif version is defined %}{% set current_tag = version %}{% else %}{% set current_tag = "Unreleased" %}{% endif -%}
-{% if timestamp is defined %}{% set current_date = timestamp | date(format="%Y-%m-%d") %}{% else %}{% set current_date = now() | date(format="%Y-%m-%d") %}{% endif %}
+body = """
+{% if tag is defined %}
+{% set current_tag = tag %}
+{% elif version is defined %}
+{% set current_tag = version %}
+{% else %}
+{% set current_tag = "Unreleased" %}
+{% endif -%}
+{% if timestamp is defined %}
+{% set current_date = timestamp | date(format="%Y-%m-%d") %}
+{% else %}
+{% set current_date = now() | date(format="%Y-%m-%d") %}
+{% endif %}
 {%- set grouped = commits | group_by(attribute="group") -%}
 {%- if grouped | length > 0 %}
 ## {{ current_tag }} - {{ current_date }}
+
 {% for group, commits in grouped %}
 ### {{ group }}
 
@@ -18,6 +30,7 @@ body = """{% if tag is defined %}{% set current_tag = tag %}{% elif version is d
 ### Internal
 
 DevOps changes only.
+
 {% endif %}
 """
 trim = true
@@ -26,7 +39,7 @@ footer = ""
 [git]
 conventional_commits = true
 filter_unconventional = true
-tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+-.*"
+tag_pattern = "^v(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
 protect_breaking_commits = true
 commit_parsers = [
     { message = "^style", group = "Internal" },

--- a/changelog/cliff.release-header.toml
+++ b/changelog/cliff.release-header.toml
@@ -1,8 +1,22 @@
 [changelog]
 header = """# Changelog\n\n"""
-body = """{% if tag is defined %}{% set current_tag = tag %}{% elif version is defined %}{% set current_tag = version %}{% else %}{% set current_tag = "Unreleased" %}{% endif %}{% if timestamp is defined %}{% set current_date = timestamp | date(format="%Y-%m-%d") %}{% else %}{% set current_date = now() | date(format="%Y-%m-%d") %}{% endif %}
+body = """
+{% if tag is defined %}
+{% set current_tag = tag %}
+{% elif version is defined %}
+{% set current_tag = version %}
+{% else %}
+{% set current_tag = "Unreleased" %}
+{% endif %}
+{% if timestamp is defined %}
+{% set current_date = timestamp | date(format="%Y-%m-%d") %}
+{% else %}
+{% set current_date = now() | date(format="%Y-%m-%d") %}
+{% endif %}
 ## {{ current_tag }} - {{ current_date }}
+
 See prereleases below.
+
 """
 trim = true
 footer = ""
@@ -10,7 +24,7 @@ footer = ""
 [git]
 conventional_commits = true
 filter_unconventional = true
-tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+tag_pattern = "^v(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
 protect_breaking_commits = true
 commit_parsers = [
     { message = "^style", group = "Internal" },

--- a/test/UlidTool.Tests/packages.lock.json
+++ b/test/UlidTool.Tests/packages.lock.json
@@ -219,9 +219,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[1.4.3, )",
-        "resolved": "1.4.3",
-        "contentHash": "/6CC/8q+Tqc6X88IFeWjkT5BobQvrY8sjf3IfCXJAOS9+BvPGMJijJyiWaR+mybkRUs8oCBeHEUudSras32EJQ==",
+        "requested": "[1.4.4, )",
+        "resolved": "1.4.4",
+        "contentHash": "1GOEzqL698z8hhSq1JAXZj7Vck8vpsgUPuZ7dGhhzk1EQumgcpZC++QExETGeEtvmsK3SNxAuLY+b8UUZWNczA==",
         "dependencies": {
           "FluentAssertions": "8.9.0",
           "Microsoft.Extensions.Configuration.Binder": "10.0.5",

--- a/test/UlidType.Tests/packages.lock.json
+++ b/test/UlidType.Tests/packages.lock.json
@@ -219,9 +219,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[1.4.3, )",
-        "resolved": "1.4.3",
-        "contentHash": "/6CC/8q+Tqc6X88IFeWjkT5BobQvrY8sjf3IfCXJAOS9+BvPGMJijJyiWaR+mybkRUs8oCBeHEUudSras32EJQ==",
+        "requested": "[1.4.4, )",
+        "resolved": "1.4.4",
+        "contentHash": "1GOEzqL698z8hhSq1JAXZj7Vck8vpsgUPuZ7dGhhzk1EQumgcpZC++QExETGeEtvmsK3SNxAuLY+b8UUZWNczA==",
         "dependencies": {
           "FluentAssertions": "8.9.0",
           "Microsoft.Extensions.Configuration.Binder": "10.0.5",


### PR DESCRIPTION
- Reformats git-cliff changelog templates for readability (one Tera statement per line)
- Splits tag_pattern into strict SemVer regexes (stable vs prerelease)
- Adds consistent blank lines in rendered markdown