### PR TITLE
Update Dependencies and CI Scrips

### DIFF
--- a/.github/CONVENTIONS.md
+++ b/.github/CONVENTIONS.md
@@ -93,13 +93,13 @@ The project owner is a non-native English speaker.
 - Files that are not shared and should be maintained separately in each repo are not marked
 - These conventions are implemented by the `diff-shared.sh` script, which is used to propagate changes from the source-of-truth files in the template content folder to the target repos. The script can be configured to specify which files are shared and how to handle changes to them. For even more nuanced and flexible control, it defines 6 different actions for handling changes to shared files:
   - **`ignore`**: do not update the target file, keep it as is
-  - **`merge_or_copy`**: ask the user to choose between ignoring, merging or copying the new content over the existing the new content.
-  - **`ask_to_merge`**: ask the user if they want to merge the new content with the existing file; if they choose not to merge, do not update the target file
+  - **`merge or copy`**: ask the user to choose between ignoring, merging or copying the new content over the existing the new content.
+  - **`ask to merge`**: ask the user if they want to merge the new content with the existing file; if they choose not to merge, do not update the target file
   - **`merge`**: open the merge utility without asking the user to merge the new content with the existing file, preserving both the shared content and the repo-specific content
-  - **`ask_to_copy`**: ask the user if they want to copy the new content over the existing file; if they choose not to copy, do not update the target file
+  - **`ask to copy`**: ask the user if they want to copy the new content over the existing file; if they choose not to copy, do not update the target file
   - **`copy`**: copy the new content over the existing file (overwriting it) without asking
 
-  By default all documents marked with **\*** are set to `copy`, and all documents marked with **\*\*** are set to `merge_or_copy`.
+  By default all documents marked with **\*** are set to `copy`, and all documents marked with **\*\*** are set to `merge or copy`.
 
   For more details on how to use the `diff-shared.sh` script, see the [tool's documentation](../vm2.DevOps/docs/diff-shared.md).
 

--- a/.github/CONVENTIONS.md
+++ b/.github/CONVENTIONS.md
@@ -93,7 +93,7 @@ The project owner is a non-native English speaker.
 - Files that are not shared and should be maintained separately in each repo are not marked
 - These conventions are implemented by the `diff-shared.sh` script, which is used to propagate changes from the source-of-truth files in the template content folder to the target repos. The script can be configured to specify which files are shared and how to handle changes to them. For even more nuanced and flexible control, it defines 6 different actions for handling changes to shared files:
   - **`ignore`**: do not update the target file, keep it as is
-  - **`merge or copy`**: ask the user to choose between ignoring, merging or copying the new content over the existing the new content.
+  - **`merge or copy`**: ask the user to choose between ignoring, merging or copying the new content over the existing new content.
   - **`ask to merge`**: ask the user if they want to merge the new content with the existing file; if they choose not to merge, do not update the target file
   - **`merge`**: open the merge utility without asking the user to merge the new content with the existing file, preserving both the shared content and the repo-specific content
   - **`ask to copy`**: ask the user if they want to copy the new content over the existing file; if they choose not to copy, do not update the target file

--- a/.github/CONVENTIONS.md
+++ b/.github/CONVENTIONS.md
@@ -93,7 +93,7 @@ The project owner is a non-native English speaker.
 - Files that are not shared and should be maintained separately in each repo are not marked
 - These conventions are implemented by the `diff-shared.sh` script, which is used to propagate changes from the source-of-truth files in the template content folder to the target repos. The script can be configured to specify which files are shared and how to handle changes to them. For even more nuanced and flexible control, it defines 6 different actions for handling changes to shared files:
   - **`ignore`**: do not update the target file, keep it as is
-  - **`merge or copy`**: ask the user to choose between ignoring, merging or copying the new content over the existing new content.
+  - **`merge or copy`**: ask the user to choose between ignoring, merging or copying the new content over the existing content.
   - **`ask to merge`**: ask the user if they want to merge the new content with the existing file; if they choose not to merge, do not update the target file
   - **`merge`**: open the merge utility without asking the user to merge the new content with the existing file, preserving both the shared content and the repo-specific content
   - **`ask to copy`**: ask the user if they want to copy the new content over the existing file; if they choose not to copy, do not update the target file

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,22 @@ on:
         default: "SHORT_RUN"
 
       reset-benchmark-thresholds:
-        description: Reset Bencher thresholds if degradation is expected.
+        description: Reset Bencher thresholds if performance degradation is expected.
+        type: boolean
+        default: false
+
+      skip-benchmarks:
+        description: If selected, the workflow will skip running benchmark tests and THE CI WORKFLOW WILL BE MARKED AS FAILED. Use only for faster testing of building and other non-benchmark test CI jobs.
+        type: boolean
+        default: false
+
+      skip-tests:
+        description: If selected, the workflow will skip running tests and THE CI WORKFLOW WILL BE MARKED AS FAILED. Use only for faster testing of building and other non-test CI jobs.
+        type: boolean
+        default: false
+
+      skip-packages:
+        description: If selected, the workflow will skip building packages and THE CI WORKFLOW WILL BE MARKED AS FAILED. Use only for faster testing of building and other non-package CI jobs.
         type: boolean
         default: false
 
@@ -88,6 +103,9 @@ jobs:
       minver-tag-prefix: ${{ steps.gather-params.outputs.minver-tag-prefix }}
       minver-prerelease-id: ${{ steps.gather-params.outputs.minver-prerelease-id }}
       reset-benchmark-thresholds: ${{ steps.gather-params.outputs.reset-benchmark-thresholds }}
+      skip-benchmarks: ${{ steps.gather-params.outputs.skip-benchmarks }}
+      skip-tests: ${{ steps.gather-params.outputs.skip-tests }}
+      skip-packages: ${{ steps.gather-params.outputs.skip-packages }}
       skip-push: ${{ steps.gather-params.outputs.skip-push }}
     steps:
       - name: Gather CI inputs
@@ -100,9 +118,6 @@ jobs:
           package-projects: ${{ env.PACKAGE_PROJECTS }}
           runners-os: ${{ env.RUNNERS_OS }}
           preprocessor-symbols: ${{ env.PREPROCESSOR_SYMBOLS }}
-          dispatch-runners-os: ${{ inputs.runners-os }}
-          dispatch-preprocessor-symbols: ${{ inputs.preprocessor-symbols }}
-          dispatch-reset-benchmark-thresholds: ${{ inputs.reset-benchmark-thresholds }}
           dotnet-version: ${{ env.DOTNET_VERSION }}
           configuration: ${{ env.CONFIGURATION }}
           min-coverage-pct: ${{ env.MIN_COVERAGE_PCT }}
@@ -111,6 +126,12 @@ jobs:
           minver-prerelease-id: ${{ env.MINVERDEFAULTPRERELEASEIDENTIFIERS }}
           reset-benchmark-thresholds: ${{ env.RESET_BENCHMARK_THRESHOLDS }}
           verbose: ${{ env.VERBOSE }}
+          dispatch-runners-os: ${{ inputs.runners-os }}
+          dispatch-preprocessor-symbols: ${{ inputs.preprocessor-symbols }}
+          dispatch-reset-benchmark-thresholds: ${{ inputs.reset-benchmark-thresholds }}
+          dispatch-skip-benchmarks: ${{ inputs.skip-benchmarks }}
+          dispatch-skip-tests: ${{ inputs.skip-tests }}
+          dispatch-skip-packages: ${{ inputs.skip-packages }}
 
   run-ci:
     name: "Run CI"
@@ -141,6 +162,9 @@ jobs:
       minver-tag-prefix: ${{ needs.prerun-ci.outputs.minver-tag-prefix }}
       minver-prerelease-id: ${{ needs.prerun-ci.outputs.minver-prerelease-id }}
       reset-benchmark-thresholds: ${{ needs.prerun-ci.outputs.reset-benchmark-thresholds == 'true' }}
+      skip-benchmarks: ${{ needs.prerun-ci.outputs.skip-benchmarks == 'true' }}
+      skip-tests: ${{ needs.prerun-ci.outputs.skip-tests == 'true' }}
+      skip-packages: ${{ needs.prerun-ci.outputs.skip-packages == 'true' }}
 
   # Gate job: single required status check for branch protection.
   # Replaces per-job required checks that break with reusable workflows + matrix (check names include
@@ -173,4 +197,21 @@ jobs:
               else
                   echo "✅  INFO: CI completed (prerun-ci: ${{ needs.prerun-ci.result }}, run-ci: ${{ needs.run-ci.result }})"
               fi
+
+              exit_code=0
+
+              if [[ "${{ needs.prerun-ci.outputs.skip-benchmarks }}" == "true" ]]; then
+                  echo "⚠️  WARNING: Benchmarks were skipped. The CI workflow is marked as failed, but it was intentional to save time. Use this option only for testing non-benchmark CI jobs faster."
+                  exit_code=1
+              fi
+              if [[ "${{ needs.prerun-ci.outputs.skip-tests }}" == "true" ]]; then
+                  echo "⚠️  WARNING: Tests were skipped. The CI workflow is marked as failed, but it was intentional to save time. Use this option only for testing non-test CI jobs faster."
+                  exit_code=1
+              fi
+              if [[ "${{ needs.prerun-ci.outputs.skip-packages }}" == "true" ]]; then
+                  echo "⚠️  WARNING: Building packages were skipped. The CI workflow is marked as failed, but it was intentional to save time. Use this option only for testing non-package CI jobs faster."
+                  exit_code=1
+              fi
+
+              exit $exit_code
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -209,7 +209,7 @@ jobs:
                   exit_code=1
               fi
               if [[ "${{ needs.prerun-ci.outputs.skip-packages }}" == "true" ]]; then
-                  echo "⚠️  WARNING: Building packages were skipped. The CI workflow is marked as failed, but it was intentional to save time. Use this option only for testing non-package CI jobs faster."
+                  echo "⚠️  WARNING: Building packages was skipped. The CI workflow is marked as failed, but it was intentional to save time. Use this option only for testing non-package CI jobs faster."
                   exit_code=1
               fi
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
         <PackageVersion Include="xunit.v3.runner.inproc" Version="3.2.2" />
         <PackageVersion Include="FluentAssertions" Version="8.10.0" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
-        <PackageVersion Include="vm2.TestUtilities" Version="1.5.0" />
+        <PackageVersion Include="vm2.TestUtilities" Version="1.5.1" />
         <!-- Benchmarking packages: -->
         <!-- for running with Visual Studio profiler:<PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />-->
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/examples/packages.lock.json
+++ b/examples/packages.lock.json
@@ -121,6 +121,12 @@
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.6.0, )",
+        "resolved": "10.6.0",
+        "contentHash": "qQDiaYWpvIymGbu+kXaMDS8YdqfeQkv6DOxPF2GSwC+eSzIKqOOnSP34TYt7gKqvB7p8/aSptexnW6nF0CUdnw=="
+      },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
         "requested": "[10.0.8, )",
@@ -272,6 +278,7 @@
           "Microsoft.Extensions.Logging.Configuration": "[10.0.8, )",
           "Microsoft.Extensions.Logging.Console": "[10.0.8, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )",
+          "Microsoft.Extensions.TimeProvider.Testing": "[10.6.0, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "System.Configuration.ConfigurationManager": "[10.0.8, )"
         }

--- a/test/UlidTool.Tests/packages.lock.json
+++ b/test/UlidTool.Tests/packages.lock.json
@@ -198,9 +198,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[1.5.0, )",
-        "resolved": "1.5.0",
-        "contentHash": "2UgQ2Hc2fCUSBIR9QGft8/rvbdLt0QKNjetkaO7ZacKOS6lP2GxJAIRLc9mdBeUfFfmzcGFzN9YdefOb7NIKPg==",
+        "requested": "[1.5.1, )",
+        "resolved": "1.5.1",
+        "contentHash": "ItST5G6Uiu9OIRE3v7azAcBI4Gtst+9WD4NP2kNQL2X1PPwD7a4etGVsQU+ZC9gxvdN3rXb0SlAMSsip5dI40w==",
         "dependencies": {
           "FluentAssertions": "8.10.0",
           "Microsoft.Extensions.Configuration.Binder": "10.0.8",
@@ -208,7 +208,6 @@
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
           "Microsoft.Extensions.Configuration.Json": "10.0.8",
           "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Hosting": "10.0.8",
           "Microsoft.Extensions.Logging": "10.0.8",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
           "Microsoft.Extensions.Logging.Configuration": "10.0.8",
@@ -289,17 +288,6 @@
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
-      "Microsoft.Extensions.Configuration.UserSecrets": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "6XTfFOnf27WY8kEeZkTZ4YNn0t+imgvdQ0YaAdR4vgURKATo9bCaVJ1KB71IOJAQtJP7Elb53VHlTNXg2CtSsA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8"
-        }
-      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.8",
@@ -309,25 +297,6 @@
         "type": "Transitive",
         "resolved": "8.0.2",
         "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
-      },
-      "Microsoft.Extensions.Diagnostics": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
@@ -351,81 +320,6 @@
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
-      },
-      "Microsoft.Extensions.Hosting": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VfEyM2BipThcSd0GG/FS2ZPCVCTiosVq2zLKEDsfeMIg78sOVZPEmS7CgWlb+dqTlgXvLSL4OG2q6sM4xRhHNg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.8",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
-          "Microsoft.Extensions.Logging.Console": "10.0.8",
-          "Microsoft.Extensions.Logging.Debug": "10.0.8",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.8",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.Debug": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "4HW3M1lGHHDwEYcDZHRNptBQ48LCI2yW+XV4vuxdfQUqafTpVT8j9RqAsez08krZKhIiaArWu8iQq5uRKZ9Ffg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.EventLog": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "kK/C3SLIoGrcZvddYQw4eMm6YaROiSYBO7YgUR5Hdv5l+GIjBmbvQK5cST2FqjeubiAOPqFEimBT2N/8wVI+3A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "System.Diagnostics.EventLog": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.EventSource": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "HX2M0MgzwQM8jpLe3AYAEMd0YsUfOP5RgGrDuk+Ki9n7HSuMbvLm9TEV3qRI3Pg9aqxc56GfgK/KdMRBhfWwKw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",

--- a/test/UlidType.Tests/packages.lock.json
+++ b/test/UlidType.Tests/packages.lock.json
@@ -198,9 +198,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[1.5.0, )",
-        "resolved": "1.5.0",
-        "contentHash": "2UgQ2Hc2fCUSBIR9QGft8/rvbdLt0QKNjetkaO7ZacKOS6lP2GxJAIRLc9mdBeUfFfmzcGFzN9YdefOb7NIKPg==",
+        "requested": "[1.5.1, )",
+        "resolved": "1.5.1",
+        "contentHash": "ItST5G6Uiu9OIRE3v7azAcBI4Gtst+9WD4NP2kNQL2X1PPwD7a4etGVsQU+ZC9gxvdN3rXb0SlAMSsip5dI40w==",
         "dependencies": {
           "FluentAssertions": "8.10.0",
           "Microsoft.Extensions.Configuration.Binder": "10.0.8",
@@ -208,7 +208,6 @@
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
           "Microsoft.Extensions.Configuration.Json": "10.0.8",
           "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Hosting": "10.0.8",
           "Microsoft.Extensions.Logging": "10.0.8",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
           "Microsoft.Extensions.Logging.Configuration": "10.0.8",
@@ -289,17 +288,6 @@
           "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
-      "Microsoft.Extensions.Configuration.UserSecrets": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "6XTfFOnf27WY8kEeZkTZ4YNn0t+imgvdQ0YaAdR4vgURKATo9bCaVJ1KB71IOJAQtJP7Elb53VHlTNXg2CtSsA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8"
-        }
-      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.8",
@@ -309,25 +297,6 @@
         "type": "Transitive",
         "resolved": "8.0.2",
         "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
-      },
-      "Microsoft.Extensions.Diagnostics": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
@@ -351,81 +320,6 @@
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
-      },
-      "Microsoft.Extensions.Hosting": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VfEyM2BipThcSd0GG/FS2ZPCVCTiosVq2zLKEDsfeMIg78sOVZPEmS7CgWlb+dqTlgXvLSL4OG2q6sM4xRhHNg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.8",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
-          "Microsoft.Extensions.Logging.Console": "10.0.8",
-          "Microsoft.Extensions.Logging.Debug": "10.0.8",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.8",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.Debug": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "4HW3M1lGHHDwEYcDZHRNptBQ48LCI2yW+XV4vuxdfQUqafTpVT8j9RqAsez08krZKhIiaArWu8iQq5uRKZ9Ffg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.EventLog": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "kK/C3SLIoGrcZvddYQw4eMm6YaROiSYBO7YgUR5Hdv5l+GIjBmbvQK5cST2FqjeubiAOPqFEimBT2N/8wVI+3A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "System.Diagnostics.EventLog": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.EventSource": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "HX2M0MgzwQM8jpLe3AYAEMd0YsUfOP5RgGrDuk+Ki9n7HSuMbvLm9TEV3qRI3Pg9aqxc56GfgK/KdMRBhfWwKw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",


### PR DESCRIPTION
# Summary

Update Dependencies and CI Scrips

## Commits

- chore: update vm2.TestUtilities package version to 1.5.1 and enhance CI workflow with skip options
- chore: fix typo in merge or copy action description in CONVENTIONS.md
- chore: update vm2.TestUtilities package version to 1.5.1 and add Microsoft.Extensions.TimeProvider.Testing dependency

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests pass locally, and cover new code and edge cases. Test coverage is above 80%.
- [x] It is not expected that the performance will degrade by more than 20%
- [x] Documentation is updated if necessary