### PR TITLE
Add OperationsPerInvoke to All Benchmarks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -255,9 +255,9 @@ dotnet_naming_rule.field_should_be_private_field.severity = warning
 dotnet_naming_rule.field_should_be_private_field.symbols = field
 dotnet_naming_rule.field_should_be_private_field.style = private_field
 
-dotnet_naming_rule.local_varaible_should_be_camel_case.severity = warning
-dotnet_naming_rule.local_varaible_should_be_camel_case.symbols = local_varaible
-dotnet_naming_rule.local_varaible_should_be_camel_case.style = camel_case
+dotnet_naming_rule.local_variable_should_be_camel_case.severity = warning
+dotnet_naming_rule.local_variable_should_be_camel_case.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camel_case.style = camel_case
 
 dotnet_naming_rule.public_delegate_should_be_pascal_case.severity = warning
 dotnet_naming_rule.public_delegate_should_be_pascal_case.symbols = public_delegate
@@ -305,9 +305,9 @@ dotnet_naming_symbols.non_public_const_member.applicable_kinds = field, local
 dotnet_naming_symbols.non_public_const_member.applicable_accessibilities = private, protected, protected_internal, private_protected, local
 dotnet_naming_symbols.non_public_const_member.required_modifiers = const
 
-dotnet_naming_symbols.local_varaible.applicable_kinds = local
-dotnet_naming_symbols.local_varaible.applicable_accessibilities = local
-dotnet_naming_symbols.local_varaible.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
 
 dotnet_naming_symbols.async_method_or_function.applicable_kinds = method, local_function
 dotnet_naming_symbols.async_method_or_function.applicable_accessibilities = *

--- a/.gitignore
+++ b/.gitignore
@@ -397,6 +397,7 @@ launchSettings.json
 
 # benchmarkDotNet results folder(s)
 TestArtifacts/
+BenchmarkArtifacts/
 BmArtifacts/
 report.txt
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
         <PackageVersion Include="xunit.v3.runner.inproc" Version="3.2.2" />
         <PackageVersion Include="FluentAssertions" Version="8.10.0" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
-        <PackageVersion Include="vm2.TestUtilities" Version="2.1.0" />
+        <PackageVersion Include="vm2.TestUtilities" Version="2.1.1" />
         <!-- Visual Studio only: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/benchmarks/Ulid/NewUlid.cs
+++ b/benchmarks/Ulid/NewUlid.cs
@@ -12,6 +12,8 @@ using vm2;
 #endif
 public class NewUlid
 {
+    const int operationsPerInvoke = 1000;
+
     [Params(nameof(CryptoRandom), nameof(PseudoRandom))]
     public string RandomProviderType { get; set; } = "";
 
@@ -31,13 +33,37 @@ public class NewUlid
     }
 
 #if GUID_BASELINE
-    [Benchmark(Description = "Guid.NewGuid", OperationsPerInvoke = 1000, Baseline = true)]
-    public Guid Guid_NewGuid() => Guid.NewGuid();
+    [Benchmark(Description = "Guid.NewGuid", OperationsPerInvoke = operationsPerInvoke, Baseline = true)]
+    public Guid Guid_NewGuid()
+    {
+        Guid id = default;
+
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = Guid.NewGuid();
+
+        return id;
+    }
 #endif
 
-    [Benchmark(Description = "Ulid.NewUlid", OperationsPerInvoke = 1000)]
-    public Ulid Ulid_NewUlid() => Ulid.NewUlid();
+    [Benchmark(Description = "Ulid.NewUlid", OperationsPerInvoke = operationsPerInvoke)]
+    public Ulid Ulid_NewUlid()
+    {
+        Ulid id = default;
 
-    [Benchmark(Description = "Factory.NewUlid", OperationsPerInvoke = 1000)]
-    public Ulid Factory_NewUlid() => Factory.NewUlid();
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = Ulid.NewUlid();
+
+        return id;
+    }
+
+    [Benchmark(Description = "Factory.NewUlid", OperationsPerInvoke = operationsPerInvoke)]
+    public Ulid Factory_NewUlid()
+    {
+        Ulid id = default;
+
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = Factory.NewUlid();
+
+        return id;
+    }
 }

--- a/benchmarks/Ulid/ParseUlid.cs
+++ b/benchmarks/Ulid/ParseUlid.cs
@@ -12,11 +12,12 @@ using vm2;
 #endif
 public class ParseUlid
 {
-    const int MaxDataItems = 1000;
-    PreGeneratedData<string> _data2 = null!;
-    PreGeneratedData<byte[]> _data3 = null!;
+    const int operationsPerInvoke = 1000;
+
+    PreGeneratedData<string> _stringData = null!;
+    PreGeneratedData<byte[]> _utf16Data = null!;
 #if GUID_BASELINE
-    PreGeneratedData<string> _data1 = null!;
+    PreGeneratedData<string> _guidStringData = null!;
 #endif
 
     [GlobalSetup]
@@ -24,21 +25,45 @@ public class ParseUlid
     {
         UlidFactory _factory = new();
 
-        _data2 = new(MaxDataItems, _ => _factory.NewUlid().ToString());
-        _data3 = new(MaxDataItems, _ => Encoding.UTF8.GetBytes(_factory.NewUlid().ToString()));
+        _stringData = new(operationsPerInvoke, _ => _factory.NewUlid().ToString());
+        _utf16Data = new(operationsPerInvoke, _ => Encoding.UTF8.GetBytes(_factory.NewUlid().ToString()));
 #if GUID_BASELINE
-        _data1 = new(MaxDataItems, _ => Guid.NewGuid().ToString());
+        _guidStringData = new(operationsPerInvoke, _ => Guid.NewGuid().ToString());
 #endif
     }
 
-    [Benchmark(Description = "Ulid.Parse(StringUtf16)", OperationsPerInvoke = 1000)]
-    public Ulid Ulid_Parse_Utf16() => Ulid.Parse(_data2.GetNext());
+    [Benchmark(Description = "Ulid.Parse(StringUtf16)", OperationsPerInvoke = operationsPerInvoke)]
+    public Ulid Ulid_Parse_Utf16()
+    {
+        Ulid id = default;
 
-    [Benchmark(Description = "Ulid.Parse(StringUtf8)", OperationsPerInvoke = 1000)]
-    public Ulid Ulid_Parse_Utf8() => Ulid.Parse(_data3.GetNext());
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = Ulid.Parse(_stringData.GetNext());
+
+        return id;
+    }
+
+    [Benchmark(Description = "Ulid.Parse(StringUtf8)", OperationsPerInvoke = operationsPerInvoke)]
+    public Ulid Ulid_Parse_Utf8()
+    {
+        Ulid id = default;
+
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = Ulid.Parse(_utf16Data.GetNext());
+
+        return id;
+    }
 
 #if GUID_BASELINE
-    [Benchmark(Description = "Guid.Parse(string)", OperationsPerInvoke = 1000, Baseline = true)]
-    public Guid Guid_Parse() => Guid.Parse(_data1.GetNext());
+    [Benchmark(Description = "Guid.Parse(string)", OperationsPerInvoke = operationsPerInvoke, Baseline = true)]
+    public Guid Guid_Parse()
+    {
+        Guid id = default;
+
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = Guid.Parse(_guidStringData.GetNext());
+
+        return id;
+    }
 #endif
 }

--- a/benchmarks/Ulid/ParseUlid.cs
+++ b/benchmarks/Ulid/ParseUlid.cs
@@ -15,7 +15,7 @@ public class ParseUlid
     const int operationsPerInvoke = 1000;
 
     PreGeneratedData<string> _stringData = null!;
-    PreGeneratedData<byte[]> _utf16Data = null!;
+    PreGeneratedData<byte[]> _utf8Data = null!;
 #if GUID_BASELINE
     PreGeneratedData<string> _guidStringData = null!;
 #endif
@@ -26,7 +26,7 @@ public class ParseUlid
         UlidFactory _factory = new();
 
         _stringData = new(operationsPerInvoke, _ => _factory.NewUlid().ToString());
-        _utf16Data = new(operationsPerInvoke, _ => Encoding.UTF8.GetBytes(_factory.NewUlid().ToString()));
+        _utf8Data = new(operationsPerInvoke, _ => Encoding.UTF8.GetBytes(_factory.NewUlid().ToString()));
 #if GUID_BASELINE
         _guidStringData = new(operationsPerInvoke, _ => Guid.NewGuid().ToString());
 #endif
@@ -49,7 +49,7 @@ public class ParseUlid
         Ulid id = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Ulid.Parse(_utf16Data.GetNext());
+            id = Ulid.Parse(_utf8Data.GetNext());
 
         return id;
     }

--- a/benchmarks/Ulid/UlidToString.cs
+++ b/benchmarks/Ulid/UlidToString.cs
@@ -12,7 +12,7 @@ using vm2;
 #endif
 public class UlidToString
 {
-    const int MaxDataItems = 1000;
+    const int operationsPerInvoke = 1000;
 
 #if GUID_BASELINE
     PreGeneratedData<Guid> _data1 = null!;
@@ -25,16 +25,32 @@ public class UlidToString
         UlidFactory _factory = new();
 
 #if GUID_BASELINE
-        _data1 = new(MaxDataItems, _ => Guid.NewGuid());
+        _data1 = new(operationsPerInvoke, _ => Guid.NewGuid());
 #endif
-        _data2 = new(MaxDataItems, _ => _factory.NewUlid());
+        _data2 = new(operationsPerInvoke, _ => _factory.NewUlid());
     }
 
 #if GUID_BASELINE
-    [Benchmark(Description = "Guid.ToString", OperationsPerInvoke = 1000, Baseline = true)]
-    public string Guid_ToString() => _data1.GetNext().ToString();
+    [Benchmark(Description = "Guid.ToString", OperationsPerInvoke = operationsPerInvoke, Baseline = true)]
+    public string Guid_ToString()
+    {
+        string id = "";
+
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = _data1.GetNext().ToString();
+
+        return id;
+    }
 #endif
 
-    [Benchmark(Description = "Ulid.ToString", OperationsPerInvoke = 1000)]
-    public string Ulid_ToString() => _data2.GetNext().ToString();
+    [Benchmark(Description = "Ulid.ToString", OperationsPerInvoke = operationsPerInvoke)]
+    public string Ulid_ToString()
+    {
+        string id = "";
+
+        for (int i = 0; i < operationsPerInvoke; i++)
+            id = _data2.GetNext().ToString();
+
+        return id;
+    }
 }

--- a/examples/packages.lock.json
+++ b/examples/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "RJxitcN5CCyZDcPNXKLsecwKvACzmy8C1z8hGM9+hFcnPhv1jDysJFFIeUHIPWaZ6wDAfYtZcgKEtegvL2Nz8A=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4y+VsQOcs4EiTSINdCpCWi/aLRbIbGTxSezQXd8uGVhzbDRm1FNVTZDyCUQixE0+g9UFusvfxVcF68YYz7RzxA=="
       },
       "Microsoft.Extensions.TimeProvider.Testing": {
         "type": "Direct",
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -65,17 +65,17 @@
     "net10.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "RJxitcN5CCyZDcPNXKLsecwKvACzmy8C1z8hGM9+hFcnPhv1jDysJFFIeUHIPWaZ6wDAfYtZcgKEtegvL2Nz8A==",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4y+VsQOcs4EiTSINdCpCWi/aLRbIbGTxSezQXd8uGVhzbDRm1FNVTZDyCUQixE0+g9UFusvfxVcF68YYz7RzxA==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.8"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.9"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "0jxyi69frgaqADCnEpHE+f65NoiRTAjfjvNDMOxWV77BumQ56eMDL4ECw29DcJTqwaYJQ92PqDS6y6CiLf7kgw=="
+        "resolved": "10.0.9",
+        "contentHash": "45CVefG8S0eUKUJ4LBWOi8FOAgMJOP6exW9l5M9OjvQaGR7jvkokBK50XaZCsO66uLxABcuzvncV8A3YiJLUgw=="
       }
     }
   }

--- a/tests/Ulid/packages.lock.json
+++ b/tests/Ulid/packages.lock.json
@@ -63,9 +63,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[2.1.0, )",
-        "resolved": "2.1.0",
-        "contentHash": "vli34yptvJt4qVDQdiaKT/dy8bV7FRkkim0MCipBr20skQsT+D8t6unltDsa2XhWw8XvZeioXHqyEGMNNF6vFg==",
+        "requested": "[2.1.1, )",
+        "resolved": "2.1.1",
+        "contentHash": "30s+vCk9vGJA2wVrMMcBXNye56vYgWbzEYLolKNGMc3GB61wvCMrS+ZM8W5enqrYXxwusvWq9Ygw7pZF6VfKdA==",
         "dependencies": {
           "FluentAssertions": "8.10.0",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.8",

--- a/tests/UlidTool/packages.lock.json
+++ b/tests/UlidTool/packages.lock.json
@@ -63,9 +63,9 @@
       },
       "vm2.TestUtilities": {
         "type": "Direct",
-        "requested": "[2.1.0, )",
-        "resolved": "2.1.0",
-        "contentHash": "vli34yptvJt4qVDQdiaKT/dy8bV7FRkkim0MCipBr20skQsT+D8t6unltDsa2XhWw8XvZeioXHqyEGMNNF6vFg==",
+        "requested": "[2.1.1, )",
+        "resolved": "2.1.1",
+        "contentHash": "30s+vCk9vGJA2wVrMMcBXNye56vYgWbzEYLolKNGMc3GB61wvCMrS+ZM8W5enqrYXxwusvWq9Ygw7pZF6VfKdA==",
         "dependencies": {
           "FluentAssertions": "8.10.0",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.8",


### PR DESCRIPTION
# Summary

Add OperationsPerInvoke to All Benchmarks

## Commits

- fix(benchmarks): correct variable names and improve benchmark operations per invoke
- chore(deps): update Microsoft packages to version 10.0.9 in packages.lock.json
- chore(deps): update vm2.TestUtilities to version 2.1.1

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests pass locally, and cover new code and edge cases. Test coverage is above 80%.
- [ ] It is not expected that the performance will degrade by more than 20%
- [x] Documentation is updated if necessary