### PR TITLE
fix(benchmarks): Rename Optimization Discards in Benchmark Methods

### DIFF
--- a/benchmarks/Ulid/NewUlid.cs
+++ b/benchmarks/Ulid/NewUlid.cs
@@ -36,34 +36,34 @@ public class NewUlid
     [Benchmark(Description = "Guid.NewGuid", OperationsPerInvoke = operationsPerInvoke, Baseline = true)]
     public Guid Guid_NewGuid()
     {
-        Guid id = default;
+        Guid suppressOptimizationDiscard = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Guid.NewGuid();
+            suppressOptimizationDiscard = Guid.NewGuid();
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 #endif
 
     [Benchmark(Description = "Ulid.NewUlid", OperationsPerInvoke = operationsPerInvoke)]
     public Ulid Ulid_NewUlid()
     {
-        Ulid id = default;
+        Ulid suppressOptimizationDiscard = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Ulid.NewUlid();
+            suppressOptimizationDiscard = Ulid.NewUlid();
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 
     [Benchmark(Description = "Factory.NewUlid", OperationsPerInvoke = operationsPerInvoke)]
     public Ulid Factory_NewUlid()
     {
-        Ulid id = default;
+        Ulid suppressOptimizationDiscard = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Factory.NewUlid();
+            suppressOptimizationDiscard = Factory.NewUlid();
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 }

--- a/benchmarks/Ulid/ParseUlid.cs
+++ b/benchmarks/Ulid/ParseUlid.cs
@@ -35,35 +35,35 @@ public class ParseUlid
     [Benchmark(Description = "Ulid.Parse(StringUtf16)", OperationsPerInvoke = operationsPerInvoke)]
     public Ulid Ulid_Parse_Utf16()
     {
-        Ulid id = default;
+        Ulid suppressOptimizationDiscard = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Ulid.Parse(_stringData.GetNext());
+            suppressOptimizationDiscard = Ulid.Parse(_stringData.GetNext());
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 
     [Benchmark(Description = "Ulid.Parse(StringUtf8)", OperationsPerInvoke = operationsPerInvoke)]
     public Ulid Ulid_Parse_Utf8()
     {
-        Ulid id = default;
+        Ulid suppressOptimizationDiscard = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Ulid.Parse(_utf8Data.GetNext());
+            suppressOptimizationDiscard = Ulid.Parse(_utf8Data.GetNext());
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 
 #if GUID_BASELINE
     [Benchmark(Description = "Guid.Parse(string)", OperationsPerInvoke = operationsPerInvoke, Baseline = true)]
     public Guid Guid_Parse()
     {
-        Guid id = default;
+        Guid suppressOptimizationDiscard = default;
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = Guid.Parse(_guidStringData.GetNext());
+            suppressOptimizationDiscard = Guid.Parse(_guidStringData.GetNext());
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 #endif
 }

--- a/benchmarks/Ulid/UlidToString.cs
+++ b/benchmarks/Ulid/UlidToString.cs
@@ -34,23 +34,23 @@ public class UlidToString
     [Benchmark(Description = "Guid.ToString", OperationsPerInvoke = operationsPerInvoke, Baseline = true)]
     public string Guid_ToString()
     {
-        string id = "";
+        string suppressOptimizationDiscard = "";
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = _data1.GetNext().ToString();
+            suppressOptimizationDiscard = _data1.GetNext().ToString();
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 #endif
 
     [Benchmark(Description = "Ulid.ToString", OperationsPerInvoke = operationsPerInvoke)]
     public string Ulid_ToString()
     {
-        string id = "";
+        string suppressOptimizationDiscard = "";
 
         for (int i = 0; i < operationsPerInvoke; i++)
-            id = _data2.GetNext().ToString();
+            suppressOptimizationDiscard = _data2.GetNext().ToString();
 
-        return id;
+        return suppressOptimizationDiscard;
     }
 }


### PR DESCRIPTION
# Summary

Rename optimization discards in benchmark methods.

## Commits

- fix(benchmarks): rename optimization discards in benchmark methods

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests pass locally, and cover new code and edge cases. Test coverage is above 80%.
- [x] It is not expected that the performance will degrade by more than 20%
- [x] Documentation is updated if necessary